### PR TITLE
Rachel/password update

### DIFF
--- a/DiversiTech/DiversiTech/urls.py
+++ b/DiversiTech/DiversiTech/urls.py
@@ -16,7 +16,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
-from users.views import CustomAuthToken
+from users.views import CustomAuthToken, APIChangePasswordView
 # from rest_framework.authtoken.views import obtain_auth_token
 
 urlpatterns = [
@@ -24,5 +24,6 @@ urlpatterns = [
     path('', include('users.urls')),
     path('api-auth/', include('rest_framework.urls')),
     path('api-token-auth/', CustomAuthToken.as_view(), name='api_token_auth'),
+    path('update-password/', APIChangePasswordView.as_view(), name='update_password'),
     path('', include('profiles.urls')),
 ]

--- a/DiversiTech/users/serializers.py
+++ b/DiversiTech/users/serializers.py
@@ -35,8 +35,7 @@ class CustomUserSerializer(serializers.ModelSerializer):
     
 class CustomUserEditSerializer(serializers.ModelSerializer):
     """
-    Serializer uses a custom validator to ensure case-insensitive uniqueness of usernames.
-    Django in-built password validation implemented
+    This is used for user detail updates to avoid error when username is unchanged.
 
     """
     class Meta:
@@ -44,3 +43,27 @@ class CustomUserEditSerializer(serializers.ModelSerializer):
         fields = '__all__'
         extra_kwargs = {'password': {'write_only': True}, 'id': {'read_only': True}}
 
+
+class UserPasswordChangeSerializer(serializers.Serializer):
+    old_password = serializers.CharField(max_length=50, write_only=True, required=True)
+    new_password = serializers.CharField(max_length=50, write_only=True, required=True)
+    new_password_confirmed = serializers.CharField(max_length=50, write_only=True, required=True)
+
+    def validate_old_password(self, value):
+        user = self.context['request'].user
+        if not user.check_password(value):
+            raise serializers.ValidationError({'old_password': 'Your old password was entered incorrectly.'})
+        return value
+    
+    def validate(self, data):
+        if data['new_password'] != data['new_password_confirmed']:
+            raise serializers.ValidationError({'new_password_confirmed': 'The two password fields did not match'})
+        validate_password(data['new_password'], self.context['request'].user)
+        return data
+    
+    def save(self, **kwargs):
+        password = self.validated_data['new_password']
+        user = self.context['request'].user
+        user.set_password(password)
+        user.save()
+        return user

--- a/DiversiTech/users/views.py
+++ b/DiversiTech/users/views.py
@@ -1,7 +1,7 @@
 from django.http import Http404
 from rest_framework.views import APIView
 from rest_framework.generics import UpdateAPIView
-from rest_framework.permissions import IsAuthenticated
+from django.contrib.auth import update_session_auth_hash
 from rest_framework.response import Response
 from rest_framework import status
 from .models import CustomUser
@@ -19,6 +19,7 @@ class APIChangePasswordView(UpdateAPIView):
         if hasattr(user, 'auth_token'):
             user.auth_token.delete()
         token, created = Token.objects.get_or_create(user=user)
+        update_session_auth_hash(request, user=user)
         #return a new token
         return Response({'token': token.key}, status=status.HTTP_200_OK)
 

--- a/DiversiTech/users/views.py
+++ b/DiversiTech/users/views.py
@@ -8,18 +8,32 @@ from .models import CustomUser
 from .serializers import CustomUserSerializer, CustomUserEditSerializer, UserPasswordChangeSerializer
 from rest_framework.authtoken.views import ObtainAuthToken
 from rest_framework.authtoken.models import Token
+from rest_framework.permissions import IsAuthenticated
 
 class APIChangePasswordView(UpdateAPIView):
-    
+    serializer_class = UserPasswordChangeSerializer
+
     def update(self, request, *args, **kwargs):
-        serializer = UserPasswordChangeSerializer(data=request.data, context={'request': request})
+        # retrieve token from request headers
+        auth_token = request.headers.get('Authorization', '').split(' ')[-1]
+
+        # validate token and retrieve user
+        try:
+            token = Token.objects.get(key=auth_token)
+            user = token.user
+        except Token.DoesNotExist:
+            return Response({'error': 'Invalid Token'}, status=status.HTTP_401_UNAUTHORIZED)
+        
+        serializer = self.get_serializer(data=request.data, context={'request': request})
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
+
         # as drf authtoken is being used, create a new token upon password update
         if hasattr(user, 'auth_token'):
             user.auth_token.delete()
         token, created = Token.objects.get_or_create(user=user)
         update_session_auth_hash(request, user=user)
+        
         #return a new token
         return Response({'token': token.key}, status=status.HTTP_200_OK)
 
@@ -38,12 +52,14 @@ class CustomAuthToken(ObtainAuthToken):
 
 
 class CustomUserList(APIView):
+    permission_classes = [IsAuthenticated]
+
     def get(self, request):
-        if not request.user.is_staff:
-            return Response(
-                {"message": "You do not have permission to view these records"},
-                status=status.HTTP_403_FORBIDDEN
-            )
+        # if not request.user.is_staff:
+        #     return Response(
+        #         {"message": "You do not have permission to view these records"},
+        #         status=status.HTTP_403_FORBIDDEN
+        #     )
         users = CustomUser.objects.all()
         serializer = CustomUserSerializer(users, many=True)
         return Response(serializer.data)

--- a/DiversiTech/users/views.py
+++ b/DiversiTech/users/views.py
@@ -15,10 +15,11 @@ class APIChangePasswordView(UpdateAPIView):
         serializer = UserPasswordChangeSerializer(data=request.data, context={'request': request})
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
-
+        # as drf authtoken is being used, create a new token upon password update
         if hasattr(user, 'auth_token'):
             user.auth_token.delete()
         token, created = Token.objects.get_or_create(user=user)
+        #return a new token
         return Response({'token': token.key}, status=status.HTTP_200_OK)
 
 

--- a/DiversiTech/users/views.py
+++ b/DiversiTech/users/views.py
@@ -8,7 +8,6 @@ from .models import CustomUser
 from .serializers import CustomUserSerializer, CustomUserEditSerializer, UserPasswordChangeSerializer
 from rest_framework.authtoken.views import ObtainAuthToken
 from rest_framework.authtoken.models import Token
-from rest_framework.permissions import IsAuthenticated
 
 class APIChangePasswordView(UpdateAPIView):
     serializer_class = UserPasswordChangeSerializer
@@ -52,14 +51,13 @@ class CustomAuthToken(ObtainAuthToken):
 
 
 class CustomUserList(APIView):
-    permission_classes = [IsAuthenticated]
 
     def get(self, request):
-        # if not request.user.is_staff:
-        #     return Response(
-        #         {"message": "You do not have permission to view these records"},
-        #         status=status.HTTP_403_FORBIDDEN
-        #     )
+        if not request.user.is_staff:
+            return Response(
+                {"message": "You do not have permission to view these records"},
+                status=status.HTTP_403_FORBIDDEN
+            )
         users = CustomUser.objects.all()
         serializer = CustomUserSerializer(users, many=True)
         return Response(serializer.data)


### PR DESCRIPTION
## Describe your changes

PUT API available for updating existing user password.
Can be accessed via url: `update-password/`
Requires three string values to be passed into the JSON body:
```
{
  "old_password": "",
  "new_password": "",
  "new_password_confirmed": ""
}
```
An **auth token is required** to be provided with the request - as this is how it identifies the user.

Checks that I have confirmed working (as per Insomnia Screenshots below):

- checks if old_password matches the existing password for the user
- checks that the new_password and new_password_confirmed match
- standard password validation applies - too common, at least 8 characters, can't be all numbers etc
- on successful update the user's token is updated and is stored in the session to prevent the user from being logged out

Also note that my error messages are returned in dictionary format. I'm not sure if that means they can be picked up and used in the front end?


![PUT password validation still works on updates](https://github.com/SheCodesAus/2024_a_dynamic_array_back_end/assets/134209192/d8ff44b6-eef6-46c0-9928-f50bdb7a31cb)
![PUT update password success with token](https://github.com/SheCodesAus/2024_a_dynamic_array_back_end/assets/134209192/b58b6a0b-5bbc-4444-a0a2-1f4cef4f9b89)
![PUT new password doesn't match new password confirmed](https://github.com/SheCodesAus/2024_a_dynamic_array_back_end/assets/134209192/0a0dc017-0836-4e13-8fb5-40a3e2eacf70)
![PUT oldpassword incorrect](https://github.com/SheCodesAus/2024_a_dynamic_array_back_end/assets/134209192/70f2522f-70b6-43e2-8528-66c2fef05dfa)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## What kind of feedback do you need?

Thorough review and test if you can :)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have recommended where to start and how to proceed with the review

